### PR TITLE
Fix logbuffer concurency

### DIFF
--- a/bulk_test.go
+++ b/bulk_test.go
@@ -22,6 +22,7 @@ func TestBulk_AddRecord(t *testing.T) {
 		"",
 		"",
 		"",
+		0,
 	})
 	if len(RecordsBulk.LogEntries) < 1 {
 		t.Error("Adding new record to bulk failed!")

--- a/hook.go
+++ b/hook.go
@@ -98,18 +98,16 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		Text = entry.Message
 	}
 
-	hook.Writer.LogsBuffer = append(
-		hook.Writer.LogsBuffer,
-		Log{
-			float64(entry.Time.Unix()) * 1000.0,
-			Level,
-			MessageToString(Text),
-			Category,
-			ClassName,
-			MethodName,
-			ThreadID,
-		},
-	)
+	hook.Writer.LogsBuffer.Append(Log{
+		float64(entry.Time.Unix()) * 1000.0,
+		Level,
+		MessageToString(Text),
+		Category,
+		ClassName,
+		MethodName,
+		ThreadID,
+		0,
+	})
 
 	if entry.Level == logrus.FatalLevel || entry.Level == logrus.PanicLevel {
 		hook.Writer.Flush()

--- a/http_test.go
+++ b/http_test.go
@@ -16,6 +16,7 @@ func TestSendRequestSuccess(t *testing.T) {
 		"",
 		"",
 		"",
+		0,
 	})
 	HTTPStatus := SendRequest(BulkToSend)
 	if HTTPStatus != 200 {
@@ -43,6 +44,7 @@ func TestSendRequestErrorResponseStatus(t *testing.T) {
 		"",
 		"",
 		"",
+		0,
 	})
 	HTTPStatus := SendRequest(BulkToSend)
 	if HTTPStatus == 200 {

--- a/log.go
+++ b/log.go
@@ -1,6 +1,9 @@
 package coralogix
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"sync"
+)
 
 // Log describe record format for Coralogix API
 type Log struct {
@@ -26,4 +29,42 @@ func (Record *Log) Size() uint64 {
 	}
 
 	return Record.size
+}
+
+type LogBuffer struct {
+	buffer []Log
+	size   uint64
+	lock   sync.Mutex
+}
+
+func (lb *LogBuffer) Append(log Log) {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+
+	lb.size += log.Size()
+	lb.buffer = append(lb.buffer, log)
+}
+
+func (lb *LogBuffer) Size() uint64 {
+	return lb.size
+}
+
+func (lb *LogBuffer) Len() int {
+	return len(lb.buffer)
+}
+
+func (lb *LogBuffer) Slice(i int) []Log {
+	lb.lock.Lock()
+	defer lb.lock.Unlock()
+
+	if i > len(lb.buffer) {
+		i = len(lb.buffer)
+	}
+	slice := lb.buffer[:i]
+	lb.buffer = lb.buffer[i:]
+	for _, l := range slice {
+		lb.size -= l.Size()
+	}
+
+	return slice
 }

--- a/log.go
+++ b/log.go
@@ -11,13 +11,19 @@ type Log struct {
 	ClassName  string  `json:"className"`  // Log record class name
 	MethodName string  `json:"methodName"` // Log record method name
 	ThreadID   string  `json:"threadId"`   // Thread ID
+
+	size uint64
 }
 
 // Size calculate log record length in bytes
-func (Record *Log) Size() int {
-	JSONRecord, err := json.Marshal(Record)
-	if err != nil {
-		return -1
+func (Record *Log) Size() uint64 {
+	if Record.size == 0 {
+		JSONRecord, err := json.Marshal(Record)
+		if err != nil {
+			return 0
+		}
+		Record.size = uint64(len(string(JSONRecord)))
 	}
-	return len(string(JSONRecord))
+
+	return Record.size
 }

--- a/log_test.go
+++ b/log_test.go
@@ -14,14 +14,15 @@ func TestLog_Size(t *testing.T) {
 		"",
 		"",
 		"",
+		0,
 	}
-	if LogRecord.Size() < 0 {
+	if LogRecord.Size() == 0 {
 		t.Error("Invalid log record size calculation!")
 	}
 }
 
 func TestLog_SizeFail(t *testing.T) {
-	if InvalidLogMessage().Size() >= 0 {
+	if InvalidLogMessage().Size() > 0 {
 		t.Error("Log size should be equals to 0 due to JSON parsing error!")
 	}
 }
@@ -35,5 +36,6 @@ func InvalidLogMessage() *Log {
 		"",
 		"",
 		"",
+		0,
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -125,7 +125,7 @@ func TestLogger_Log(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 {
 		t.Error("New log message add failed!")
 	}
 }
@@ -142,8 +142,8 @@ func TestLogger_Debug(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Debug("Test debug message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.DEBUG {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.DEBUG {
 		t.Error("Debug log message add failed!")
 	}
 }
@@ -160,8 +160,8 @@ func TestLogger_Verbose(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Verbose("Test verbose message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.VERBOSE {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.VERBOSE {
 		t.Error("Verbose log message add failed!")
 	}
 }
@@ -178,8 +178,8 @@ func TestLogger_Info(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Info("Test info message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.INFO {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.INFO {
 		t.Error("Info log message add failed!")
 	}
 }
@@ -196,8 +196,8 @@ func TestLogger_Warning(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Warning("Test warning message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.WARNING {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.WARNING {
 		t.Error("Warning log message add failed!")
 	}
 }
@@ -214,8 +214,8 @@ func TestLogger_Error(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Error("Test error message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.ERROR {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.ERROR {
 		t.Error("Error log message add failed!")
 	}
 }
@@ -232,8 +232,8 @@ func TestLogger_Critical(t *testing.T) {
 	defer NewLoggerTestInstance.Destroy()
 	NewLoggerTestInstance.LoggerManager.Stop()
 	NewLoggerTestInstance.Critical("Test critical message")
-	if NewLoggerTestInstance.LoggerManager.LogsBufferSize() < 1 ||
-		NewLoggerTestInstance.LoggerManager.LogsBuffer[0].Severity != Level.CRITICAL {
+	if NewLoggerTestInstance.LoggerManager.LogsBuffer.Len() < 1 ||
+		NewLoggerTestInstance.LoggerManager.LogsBuffer.Slice(1)[0].Severity != Level.CRITICAL {
 		t.Error("Critical log message add failed!")
 	}
 }

--- a/manager.go
+++ b/manager.go
@@ -93,9 +93,10 @@ func (manager *LoggerManager) AddLogLine(Severity uint, Text interface{}, Catego
 			ClassName,
 			MethodName,
 			ThreadID,
+			0,
 		}
 
-		if MaxLogChunkSize <= uint64(NewLogRecord.Size()) {
+		if MaxLogChunkSize <= NewLogRecord.Size() {
 			DebugLogger.Printf(
 				"AddLogLine(): received log message too big of size= %d MB, bigger than max_log_chunk_size= %d; throwing...\n",
 				NewLogRecord.Size()/(1024*1024),

--- a/manager.go
+++ b/manager.go
@@ -13,7 +13,7 @@ type LoggerManager struct {
 	TimeDelta           float64        // Time difference between local machine and Coralogix servers
 	TimeDeltaLastUpdate int            // Last time-delta update time
 	Stopped             bool           // Is current logger manager stopped
-	LogsBuffer          []Log          // Logs buffer
+	LogsBuffer          LogBuffer      // Logs buffer
 	Credentials                        // Credentials for Coralogix account
 	Lock                sync.WaitGroup // CoralogixLogger manager locker
 }
@@ -25,7 +25,7 @@ func NewLoggerManager(PrivateKey string, ApplicationName string, SubsystemName s
 		0,
 		0,
 		false,
-		[]Log{},
+		LogBuffer{},
 		Credentials{
 			PrivateKey,
 			ApplicationName,
@@ -38,21 +38,6 @@ func NewLoggerManager(PrivateKey string, ApplicationName string, SubsystemName s
 
 	LoggerManagerInstance.SendInitMessage()
 	return LoggerManagerInstance
-}
-
-// LogsBufferLength calculate buffer length in bytes
-func (manager *LoggerManager) LogsBufferLength() uint64 {
-	JSONBuffer, err := json.Marshal(manager.LogsBuffer)
-	if err != nil {
-		DebugLogger.Println("Can't convert to JSON: ", err)
-		return 0
-	}
-	return uint64(len(JSONBuffer))
-}
-
-// LogsBufferSize return buffer entries count
-func (manager *LoggerManager) LogsBufferSize() int {
-	return len(manager.LogsBuffer)
 }
 
 // SendInitMessage send initialization message to Coralogix for connection verify
@@ -74,7 +59,7 @@ func (manager *LoggerManager) SendInitMessage() {
 
 // AddLogLine push log record to buffer
 func (manager *LoggerManager) AddLogLine(Severity uint, Text interface{}, Category string, ClassName string, MethodName string, ThreadID string) {
-	if manager.LogsBufferLength() < MaxLogBufferSize {
+	if manager.LogsBuffer.Size() < MaxLogBufferSize {
 		if Severity < Level.DEBUG || Severity > Level.CRITICAL {
 			Severity = Level.INFO
 		}
@@ -105,7 +90,7 @@ func (manager *LoggerManager) AddLogLine(Severity uint, Text interface{}, Catego
 			return
 		}
 
-		manager.LogsBuffer = append(manager.LogsBuffer, NewLogRecord)
+		manager.LogsBuffer.Append(NewLogRecord)
 	}
 }
 
@@ -115,26 +100,26 @@ func (manager *LoggerManager) SendBulk(SyncTime bool) bool {
 		manager.UpdateTimeDeltaInterval()
 	}
 
-	BufferSizeToSend := manager.LogsBufferSize()
-	if BufferSizeToSend < 1 {
-		DebugLogger.Println("Buffer is empty, there is nothing to send!")
+	BufferLenToSend := manager.LogsBuffer.Len()
+	if BufferLenToSend < 1 {
+		DebugLogger.Println("buffer is empty, there is nothing to send!")
 		return false
 	}
 
-	for manager.LogsBufferLength() > MaxLogChunkSize && BufferSizeToSend > 1 {
-		BufferSizeToSend = int(BufferSizeToSend / 2)
+	for manager.LogsBuffer.Size() > MaxLogChunkSize && BufferLenToSend > 1 {
+		BufferLenToSend = BufferLenToSend / 2
 	}
 
-	if BufferSizeToSend < 1 {
-		BufferSizeToSend = 1
+	if BufferLenToSend < 1 {
+		BufferLenToSend = 1
 	}
 
-	DebugLogger.Println("Checking buffer size. Total log entries is:", BufferSizeToSend)
+	DebugLogger.Println("Checking buffer size. Total log entries is:", BufferLenToSend)
 	LogsBulk := NewBulk(manager.Credentials)
-	for _, Record := range manager.LogsBuffer[:BufferSizeToSend] {
+	for _, Record := range manager.LogsBuffer.Slice(BufferLenToSend) {
 		LogsBulk.AddRecord(Record)
 	}
-	manager.LogsBuffer = manager.LogsBuffer[BufferSizeToSend:]
+
 	SendRequest(LogsBulk)
 	return true
 }
@@ -153,7 +138,7 @@ func (manager *LoggerManager) Run() {
 
 		manager.SendBulk(manager.SyncTime)
 
-		if manager.LogsBufferLength() > (MaxLogChunkSize / 2) {
+		if manager.LogsBuffer.Size() > (MaxLogChunkSize / 2) {
 			NextSendInterval = FastSendSpeedInterval
 		} else {
 			NextSendInterval = NormalSendSpeedInterval

--- a/manager_test.go
+++ b/manager_test.go
@@ -17,7 +17,7 @@ type TestDummyStruct struct {
 func TestNewLoggerManager(t *testing.T) {
 	NewLoggerManagerTestInstance := CreateLoggerManager()
 	if reflect.TypeOf(NewLoggerManagerTestInstance) != reflect.TypeOf(&LoggerManager{}) ||
-		!strings.Contains(NewLoggerManagerTestInstance.LogsBuffer[0].Text, sdkVersion) {
+		!strings.Contains(NewLoggerManagerTestInstance.LogsBuffer.Slice(1)[0].Text, sdkVersion) {
 		t.Error("CoralogixLogger manager creation failed!")
 	}
 }
@@ -32,7 +32,7 @@ func TestLoggerManager_LogsBufferSize(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBufferSize() != 2 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() != 2 {
 		t.Error("Failed to check logs buffer size!")
 	}
 }
@@ -47,15 +47,16 @@ func TestLoggerManager_LogsBufferLength(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBufferSize() == 0 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() == 0 {
 		t.Error("Failed to check logs buffer length!")
 	}
 }
 
 func TestLoggerManager_LogsBufferLengthFail(t *testing.T) {
 	NewLoggerManagerTestInstance := CreateLoggerManager()
-	NewLoggerManagerTestInstance.LogsBuffer = []Log{*InvalidLogMessage()}
-	if NewLoggerManagerTestInstance.LogsBufferLength() > 0 {
+	NewLoggerManagerTestInstance.LogsBuffer = LogBuffer{}
+	NewLoggerManagerTestInstance.LogsBuffer.Append(*InvalidLogMessage())
+	if NewLoggerManagerTestInstance.LogsBuffer.Size() > 0 {
 		t.Error("Buffer length should fail due to incorrect content!")
 	}
 }
@@ -63,7 +64,7 @@ func TestLoggerManager_LogsBufferLengthFail(t *testing.T) {
 func TestLoggerManager_SendInitMessage(t *testing.T) {
 	NewLoggerManagerTestInstance := CreateLoggerManager()
 	NewLoggerManagerTestInstance.SendInitMessage()
-	if !strings.Contains(NewLoggerManagerTestInstance.LogsBuffer[1].Text, sdkVersion) {
+	if !strings.Contains(NewLoggerManagerTestInstance.LogsBuffer.Slice(2)[1].Text, sdkVersion) {
 		t.Error("Initial message sending failed!")
 	}
 }
@@ -78,7 +79,7 @@ func TestLoggerManager_AddLogLine(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBufferSize() != 2 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() != 2 {
 		t.Error("Failed to add log to buffer!")
 	}
 }
@@ -93,7 +94,7 @@ func TestLoggerManager_AddLogLineWithInvalidSeverity(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBuffer[1].Severity != Level.INFO {
+	if NewLoggerManagerTestInstance.LogsBuffer.Slice(2)[1].Severity != Level.INFO {
 		t.Error("Severity checking failed!")
 	}
 }
@@ -108,7 +109,7 @@ func TestLoggerManager_AddLogLineWithEmptyText(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBuffer[1].Text != "EMPTY_STRING" {
+	if NewLoggerManagerTestInstance.LogsBuffer.Slice(2)[1].Text != "EMPTY_STRING" {
 		t.Error("Log text checking failed!")
 	}
 }
@@ -123,7 +124,7 @@ func TestLoggerManager_AddLogLineWithNil(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBuffer[1].Text != "EMPTY_STRING" {
+	if NewLoggerManagerTestInstance.LogsBuffer.Slice(2)[1].Text != "EMPTY_STRING" {
 		t.Error("Log text checking failed!")
 	}
 }
@@ -138,7 +139,7 @@ func TestLoggerManager_AddLogLineWithEmptyCategory(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBuffer[1].Category != LogCategory {
+	if NewLoggerManagerTestInstance.LogsBuffer.Slice(2)[1].Category != LogCategory {
 		t.Error("Log category checking failed!")
 	}
 }
@@ -153,7 +154,7 @@ func TestLoggerManager_AddLogLineOverflow(t *testing.T) {
 		"",
 		"",
 	)
-	if NewLoggerManagerTestInstance.LogsBufferSize() > 1 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() > 1 {
 		t.Error("Failed to check log record max length!")
 	}
 }
@@ -169,14 +170,14 @@ func TestLoggerManager_SendBulk(t *testing.T) {
 		"",
 	)
 	if NewLoggerManagerTestInstance.SendBulk(true) != true ||
-		NewLoggerManagerTestInstance.LogsBufferSize() > 0 {
+		NewLoggerManagerTestInstance.LogsBuffer.Len() > 0 {
 		t.Error("Failed to check log record max length!")
 	}
 }
 
 func TestLoggerManager_SendBulkWithEmptyBuffer(t *testing.T) {
 	NewLoggerManagerTestInstance := CreateLoggerManager()
-	NewLoggerManagerTestInstance.LogsBuffer = []Log{}
+	NewLoggerManagerTestInstance.LogsBuffer = LogBuffer{}
 	if NewLoggerManagerTestInstance.SendBulk(true) != false {
 		t.Error("Unexpected behavior when sending empty buffer!")
 	}
@@ -195,7 +196,7 @@ func TestLoggerManager_SendBulkWithBigBuffer(t *testing.T) {
 		)
 	}
 	NewLoggerManagerTestInstance.SendBulk(true)
-	if NewLoggerManagerTestInstance.LogsBufferSize() == 0 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() == 0 {
 		t.Error("Incorrect buffer chunk process!")
 	}
 }
@@ -211,7 +212,7 @@ func TestLoggerManager_Flush(t *testing.T) {
 		"",
 	)
 	NewLoggerManagerTestInstance.Flush()
-	if NewLoggerManagerTestInstance.LogsBufferSize() > 0 {
+	if NewLoggerManagerTestInstance.LogsBuffer.Len() > 0 {
 		t.Error("Logs buffer flush failed!")
 	}
 }


### PR DESCRIPTION
added `LogBuffer` struct to hold a mutex in order to lock/unlock when appending/removing logs from the buffer

the original code below runs parallel and has a race condition.
this could cause missing logs been appended/sent to coralogix
```
// the code that appends the log
manager.LogsBuffer = append(manager.LogsBuffer, NewLogRecord)

// the code that trims the logs (run in another goroutine)
manager.LogsBuffer = manager.LogsBuffer[BufferSizeToSend:]
```

added a fix to use a mutex. 
also extracted some functions to the `LogBuffer` struct (like Size, Len, Slice)

I believe this fixes: https://github.com/coralogix/go-coralogix-sdk/issues/9

