### PR TITLE
fix 100% cpu

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,5 +1,7 @@
 package coralogix
 
+import "time"
+
 const (
 	// MaxLogBufferSize is maximum log buffer size (default=128MiB)
 	MaxLogBufferSize uint64 = 128 * (1024 * 1024)
@@ -8,10 +10,10 @@ const (
 	MaxLogChunkSize uint64 = 1.5 * (1024 * 1024)
 
 	// NormalSendSpeedInterval is a bulk send interval in normal mode
-	NormalSendSpeedInterval float64 = 0.5
+	NormalSendSpeedInterval = 1 * time.Second
 
 	// FastSendSpeedInterval is a bulk send interval in fast mode
-	FastSendSpeedInterval float64 = 0.1
+	FastSendSpeedInterval = 500 * time.Millisecond
 
 	// TimeDelayTimeout is a timeout for time-delay request
 	TimeDelayTimeout uint = 5

--- a/manager.go
+++ b/manager.go
@@ -13,6 +13,7 @@ type LoggerManager struct {
 	TimeDelta           float64        // Time difference between local machine and Coralogix servers
 	TimeDeltaLastUpdate int            // Last time-delta update time
 	Stopped             bool           // Is current logger manager stopped
+	SendInterval        time.Duration  // Send bulk logs interval
 	LogsBuffer          LogBuffer      // Logs buffer
 	Credentials                        // Credentials for Coralogix account
 	Lock                sync.WaitGroup // CoralogixLogger manager locker
@@ -25,6 +26,7 @@ func NewLoggerManager(PrivateKey string, ApplicationName string, SubsystemName s
 		0,
 		0,
 		false,
+		0,
 		LogBuffer{},
 		Credentials{
 			PrivateKey,
@@ -138,10 +140,14 @@ func (manager *LoggerManager) Run() {
 
 		manager.SendBulk(manager.SyncTime)
 
-		if manager.LogsBuffer.Size() > (MaxLogChunkSize / 2) {
-			NextSendInterval = FastSendSpeedInterval
+		if manager.SendInterval > 0 {
+			NextSendInterval = manager.SendInterval
 		} else {
-			NextSendInterval = NormalSendSpeedInterval
+			if manager.LogsBuffer.Size() > (MaxLogChunkSize / 2) {
+				NextSendInterval = FastSendSpeedInterval
+			} else {
+				NextSendInterval = NormalSendSpeedInterval
+			}
 		}
 
 		DebugLogger.Printf("Next buffer check is scheduled in %.1f seconds\n", NextSendInterval)

--- a/manager.go
+++ b/manager.go
@@ -128,7 +128,7 @@ func (manager *LoggerManager) SendBulk(SyncTime bool) bool {
 
 // Run should work in separate thread and asynchronously operate with logs
 func (manager *LoggerManager) Run() {
-	var NextSendInterval float64
+	var NextSendInterval time.Duration
 
 	defer manager.Lock.Done()
 
@@ -151,7 +151,7 @@ func (manager *LoggerManager) Run() {
 		}
 
 		DebugLogger.Printf("Next buffer check is scheduled in %.1f seconds\n", NextSendInterval)
-		time.Sleep(time.Duration(NextSendInterval) * time.Second)
+		time.Sleep(NextSendInterval)
 	}
 }
 


### PR DESCRIPTION
well, this is quite funny... in `go` 
```
var num float64 = 0.5
time.Duration(num) == 0. (because type Duration = int64)
```
this made `time.Sleep(time.Duration(NextSendInterval) * time.Second)` to be the same as `time.Sleep(0 * time.Second)`
that made the 100% CPU (as described here: https://github.com/coralogix/go-coralogix-sdk/issues/6) because the for loop never sleep

better to use an explicit `time.Duration` type. plus i added an option to override this property when creating the logger

i belive this fixes issues: 
https://github.com/coralogix/go-coralogix-sdk/issues/11
https://github.com/coralogix/go-coralogix-sdk/issues/6