### PR TITLE
add ms to timestamp

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -73,7 +73,7 @@ func (manager *LoggerManager) AddLogLine(Severity uint, Text interface{}, Catego
 		}
 
 		NewLogRecord := Log{
-			float64(time.Now().Unix())*1000.0 + manager.TimeDelta,
+			float64(time.Now().UnixMilli()) + manager.TimeDelta,
 			Severity,
 			MessageToString(Text),
 			Category,

--- a/slog_handler.go
+++ b/slog_handler.go
@@ -149,6 +149,8 @@ func (h *CoralogixHandler) Stop() {
 
 func attrToMap(m map[string]any, a slog.Attr) {
 	switch v := a.Value.Any().(type) {
+	case error:
+		m[a.Key] = v.Error()
 	case []slog.Attr:
 		m2 := map[string]any{}
 		for _, a2 := range v {

--- a/slog_handler_test.go
+++ b/slog_handler_test.go
@@ -1,6 +1,7 @@
 package coralogix
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -29,10 +30,12 @@ func TestSlogHandler_AttrToMap(t *testing.T) {
 	m1 := map[string]any{}
 	attrToMap(m1, slog.String("1", "1"))
 	attrToMap(m1, slog.Int("2", 2))
+	attrToMap(m1, slog.Any("error", errors.New("test")))
 
 	assert.Equal(t, map[string]any{
-		"1": "1",
-		"2": int64(2),
+		"1":     "1",
+		"2":     int64(2),
+		"error": "test",
 	}, m1)
 
 	m2 := map[string]any{}


### PR DESCRIPTION
@daidokoro 
please have a look.. we saw that the sdk is missing the `ms` in the timestamp. 
it causes disorder on logs send on the same second. 