### PR TITLE
sync time only if buffer is not empty

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -98,14 +98,14 @@ func (manager *LoggerManager) AddLogLine(Severity uint, Text interface{}, Catego
 
 // SendBulk send logs bulk to Coralogix
 func (manager *LoggerManager) SendBulk(SyncTime bool) bool {
-	if SyncTime {
-		manager.UpdateTimeDeltaInterval()
-	}
-
 	BufferLenToSend := manager.LogsBuffer.Len()
 	if BufferLenToSend < 1 {
 		DebugLogger.Println("buffer is empty, there is nothing to send!")
 		return false
+	}
+
+	if SyncTime {
+		manager.UpdateTimeDeltaInterval()
 	}
 
 	for manager.LogsBuffer.Size() > MaxLogChunkSize && BufferLenToSend > 1 {


### PR DESCRIPTION
no need to do a time sync if the buffer of logs to send is empty.
only if there are logs to send, it should do a time sync.
