### PR TITLE
Update the authentication to be in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Coralogix Go SDK
-
+## Deprecation Notics: this code will be derecated in favore of [OTEl SDK](https://github.com/open-telemetry/opentelemetry-go?tab=readme-ov-file), and will no longer be supported, as of 22.9.2025
 [![goreportcard](https://goreportcard.com/badge/github.com/coralogix/go-coralogix-sdk)](https://goreportcard.com/report/github.com/coralogix/go-coralogix-sdk)
 [![Go Reference](https://pkg.go.dev/badge/github.com/coralogix/go-coralogix-sdk.svg)](https://pkg.go.dev/github.com/coralogix/go-coralogix-sdk)
 [![license](https://img.shields.io/github/license/coralogix/go-coralogix-sdk.svg)](https://raw.githubusercontent.com/coralogix/go-coralogix-sdk/master/LICENSE)

--- a/bulk.go
+++ b/bulk.go
@@ -7,7 +7,6 @@ import (
 
 // Bulk describe logs batch format for Coralogix API
 type Bulk struct {
-	PrivateKey      string `json:"privateKey"`      // Coralogix private key
 	ApplicationName string `json:"applicationName"` // Your application name
 	SubsystemName   string `json:"subsystemName"`   // Subsystem name of your application
 	ComputerName    string `json:"computerName"`    // Current machine hostname
@@ -18,11 +17,10 @@ type Bulk struct {
 func NewBulk(Credentials Credentials) *Bulk {
 	Hostname, _ := os.Hostname()
 	return &Bulk{
-		Credentials.PrivateKey,
-		Credentials.ApplicationName,
-		Credentials.SubsystemName,
-		Hostname,
-		[]Log{},
+		ApplicationName: Credentials.ApplicationName,
+		SubsystemName:   Credentials.SubsystemName,
+		ComputerName:    Hostname,
+		LogEntries:      []Log{},
 	}
 }
 

--- a/constant.go
+++ b/constant.go
@@ -51,10 +51,10 @@ const (
 
 var (
 	// LogURL is the Coralogix logs url endpoint
-	LogURL string = GetEnv("CORALOGIX_LOG_URL", "https://api.coralogix.com:443/api/v1/logs")
+	LogURL string = GetEnv("CORALOGIX_LOG_URL", "https://ingress.eu1.coralogix.com:443/api/v1/logs")
 
 	// TimeDeltaURL is the Coralogix time delay url endpoint
-	TimeDeltaURL string = GetEnv("CORALOGIX_TIME_DELTA_URL", "https://api.coralogix.com:443/sdk/v1/time")
+	TimeDeltaURL string = GetEnv("CORALOGIX_TIME_DELTA_URL", "https://ingress.eu1.coralogix.com:443/sdk/v1/time")
 
 	// Headers is the list of headers added to each send logs request
 	Headers http.Header = func() http.Header {

--- a/constant.go
+++ b/constant.go
@@ -65,7 +65,7 @@ var (
 			mimeHeader = map[string][]string{}
 		}
 		mimeHeader.Set("Content-Type", "application/json")
-		mimeHeader.Set("Authorization", "Bearer "+GetEnv("PRIVATE_KEY", ""))
+		// Note: Authorization header is now set dynamically in SendRequest
 		return http.Header(mimeHeader)
 	}()
 )

--- a/constant.go
+++ b/constant.go
@@ -65,6 +65,7 @@ var (
 			mimeHeader = map[string][]string{}
 		}
 		mimeHeader.Set("Content-Type", "application/json")
+		mimeHeader.Set("Authorization", "Bearer "+GetEnv("PRIVATE_KEY", ""))
 		return http.Header(mimeHeader)
 	}()
 )

--- a/http.go
+++ b/http.go
@@ -49,7 +49,7 @@ func SendRequest(Bulk *Bulk, privateKey string) int {
 }
 
 // GetTimeSync synchronize logs time with Coralogix servers time
-func GetTimeSync() (bool, float64) {
+func GetTimeSync(privateKey string) (bool, float64) {
 	DebugLogger.Println("Syncing time with Coralogix server...")
 
 	client := &http.Client{
@@ -61,7 +61,12 @@ func GetTimeSync() (bool, float64) {
 		DebugLogger.Println("Can't create HTTP request:", err)
 		return false, 0
 	}
-	request.Header = Headers
+
+	// Set headers with dynamic Authorization header
+	request.Header = Headers.Clone()
+	if privateKey != "" {
+		request.Header.Set("Authorization", "Bearer "+privateKey)
+	}
 
 	response, err := client.Do(request)
 	if err != nil {

--- a/http.go
+++ b/http.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SendRequest send logs data to Coralogix server
-func SendRequest(Bulk *Bulk) int {
+func SendRequest(Bulk *Bulk, privateKey string) int {
 	client := &http.Client{
 		Timeout: time.Duration(HTTPTimeout) * time.Second,
 	}
@@ -22,7 +22,12 @@ func SendRequest(Bulk *Bulk) int {
 			DebugLogger.Println("Can't create HTTP request:", err)
 			continue
 		}
-		request.Header = Headers
+
+		// Set headers with dynamic Authorization header
+		request.Header = Headers.Clone()
+		if privateKey != "" {
+			request.Header.Set("Authorization", "Bearer "+privateKey)
+		}
 
 		response, err := client.Do(request)
 		if err != nil {

--- a/http_test.go
+++ b/http_test.go
@@ -18,7 +18,7 @@ func TestSendRequestSuccess(t *testing.T) {
 		"",
 		0,
 	})
-	HTTPStatus := SendRequest(BulkToSend)
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
 	if HTTPStatus != 200 {
 		t.Error("Logs bulk sending failed!")
 	}
@@ -30,7 +30,7 @@ func TestSendRequestPostFail(t *testing.T) {
 	SetDebug(true)
 	BulkToSend := CreateBulk()
 	BulkToSend.AddRecord(*InvalidLogMessage())
-	HTTPStatus := SendRequest(BulkToSend)
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
 	if HTTPStatus > 0 {
 		t.Error("Sending of invalid request should be failed!")
 	}
@@ -50,7 +50,7 @@ func TestSendRequestErrorResponseStatus(t *testing.T) {
 		"",
 		0,
 	})
-	HTTPStatus := SendRequest(BulkToSend)
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
 	if HTTPStatus == 0 {
 		t.Error("Logs bulk was successful!")
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -57,7 +57,7 @@ func TestSendRequestErrorResponseStatus(t *testing.T) {
 }
 
 func TestGetTimeSync(t *testing.T) {
-	Status, TimeDelta := GetTimeSync()
+	Status, TimeDelta := GetTimeSync(GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
 	if Status == false || reflect.TypeOf(TimeDelta).Kind() != reflect.Float64 {
 		t.Error("Time synchronization failed!")
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -18,7 +18,7 @@ func TestSendRequestSuccess(t *testing.T) {
 		"",
 		0,
 	})
-	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "dummy-key-123"))
 	if HTTPStatus != 200 {
 		t.Error("Logs bulk sending failed!")
 	}
@@ -30,7 +30,7 @@ func TestSendRequestPostFail(t *testing.T) {
 	SetDebug(true)
 	BulkToSend := CreateBulk()
 	BulkToSend.AddRecord(*InvalidLogMessage())
-	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "dummy-key-123"))
 	if HTTPStatus > 0 {
 		t.Error("Sending of invalid request should be failed!")
 	}
@@ -50,14 +50,14 @@ func TestSendRequestErrorResponseStatus(t *testing.T) {
 		"",
 		0,
 	})
-	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
+	HTTPStatus := SendRequest(BulkToSend, GetEnv("PRIVATE_KEY", "dummy-key-123"))
 	if HTTPStatus == 0 {
 		t.Error("Logs bulk was successful!")
 	}
 }
 
 func TestGetTimeSync(t *testing.T) {
-	Status, TimeDelta := GetTimeSync(GetEnv("PRIVATE_KEY", "7569303a-6269-4d2c-bf14-1aec9b1786a4"))
+	Status, TimeDelta := GetTimeSync(GetEnv("PRIVATE_KEY", "dummy-key-123"))
 	if Status == false || reflect.TypeOf(TimeDelta).Kind() != reflect.Float64 {
 		t.Error("Time synchronization failed!")
 	}

--- a/manager.go
+++ b/manager.go
@@ -123,7 +123,7 @@ func (manager *LoggerManager) SendBulk(SyncTime bool) bool {
 		LogsBulk.AddRecord(Record)
 	}
 
-	SendRequest(LogsBulk)
+	SendRequest(LogsBulk, manager.PrivateKey)
 	return true
 }
 

--- a/manager.go
+++ b/manager.go
@@ -194,7 +194,7 @@ func MessageToString(Message interface{}) string {
 // UpdateTimeDeltaInterval get time difference between local machine and Coralogix servers
 func (manager *LoggerManager) UpdateTimeDeltaInterval() {
 	if (uint(int(time.Now().Unix()) - manager.TimeDeltaLastUpdate)) >= 60*SyncTimeUpdateInterval {
-		Result, TimeDelta := GetTimeSync()
+		Result, TimeDelta := GetTimeSync(manager.PrivateKey)
 		if Result {
 			manager.TimeDelta = TimeDelta
 			manager.TimeDeltaLastUpdate = int(time.Now().Unix())


### PR DESCRIPTION
Change the code authentication of the code with coralogix to send a header with `Authorization Bearer privateKey` instead of sending the private key in the body of the request
Change the default endpoint to CX to new ones:
* CORALOGIX_LOG_URL -> https://ingress.eu1.coralogix.com:443/api/v1/logs 
* CORALOGIX_TIME_DELTA_URL -> https://ingress.eu1.coralogix.com:443/sdk/v1/time
Add a deprecation Note for the module